### PR TITLE
Handle obsolete Gradle configuratiion

### DIFF
--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -6,7 +6,7 @@ repositories{
 }
 
 dependencies {
-    compile(name:'barcodescanner-release-2.1.5', ext:'aar')
+    implementation(name:'barcodescanner-release-2.1.5', ext:'aar')
 }
 
 android {


### PR DESCRIPTION
One property of Gradle Configuration has been made deprecated and now Obsolete, as mentioned in: https://developer.android.com/studio/releases/gradle-plugin#optimizations

To fix it, request to accept this PR .

References:
https://stackoverflow.com/a/44493379