### PR TITLE
Remove JCenter dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "5r1m-phonegap-plugin-barcodescanner",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "You can use the BarcodeScanner plugin to scan different types of barcodes (using the device's camera) and get the metadata encoded in them for processing within your application.",
   "cordova": {
     "id": "5r1m-phonegap-plugin-barcodescanner",

--- a/plugin.xml
+++ b/plugin.xml
@@ -42,9 +42,7 @@
       <uses-feature android:name="android.hardware.camera" android:required="true"/>
     </config-file>
     <framework src="src/android/barcodescanner.gradle" custom="true" type="gradleReference"/>
-    <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION"/>
     <lib-file src="src/android/barcodescanner-release-2.1.5.aar"/>
-    <preference name="ANDROID_SUPPORT_V4_VERSION" default="27.+"/>
   </platform>
   <platform name="windows">
     <js-module src="src/windows/BarcodeScannerProxy.js" name="BarcodeScannerProxy">

--- a/src/android/barcodescanner.gradle
+++ b/src/android/barcodescanner.gradle
@@ -1,5 +1,6 @@
 repositories{
-    jcenter()
+    google()
+    mavenCentral()
     flatDir{
         dirs 'libs'
     }


### PR DESCRIPTION
## Summary
Removes deprecated JCenter repository to modernize the plugin for current Android toolchains.

## Changes Made
- Removed `jcenter()` from `barcodescanner.gradle`
- Added `google()` and `mavenCentral()` repositories
- Removed unnecessary support-v4 dependency (plugin only uses standard Android SDK)
- Removed `ANDROID_SUPPORT_V4_VERSION` preference
- Bumped version to `1.4.0`

## Testing
- Built successfully with Cordova Android 13
- Runtime tested: barcode scanning functionality works correctly
- APK generated and deployed to device without errors

## Background
JCenter was shut down by JFrog in 2021. This migrates to the standard Google Maven and Maven Central repositories to prevent future build failures.